### PR TITLE
Update i2c supported functions for 64 bit

### DIFF
--- a/src/i2c.c
+++ b/src/i2c.c
@@ -42,7 +42,7 @@ static int _i2c_error(struct i2c_handle *i2c, int code, int c_errno, const char 
 }
 
 int i2c_open(i2c_t *i2c, const char *path) {
-    uint32_t supported_funcs;
+    unsigned long supported_funcs;
 
     memset(i2c, 0, sizeof(struct i2c_handle));
 


### PR DESCRIPTION
Update to change supported_funcs to unsigned long to
support 64 bit builds.  Without this change, the value of
supported_funcs is 0 even though the correct value for
the device I tested with is fff8009.

Signed-off-by: Jared Bents <jared.bents@rockwellcollins.com>