### PR TITLE
serial: fix issue with 8th bit being stripped when using parity

### DIFF
--- a/src/serial.c
+++ b/src/serial.c
@@ -159,7 +159,10 @@ int serial_open_advanced(serial_t *serial, const char *path, uint32_t baudrate, 
     /* Ignore break characters */
     termios_settings.c_iflag = IGNBRK;
     if (parity != PARITY_NONE)
-        termios_settings.c_iflag |= (INPCK | ISTRIP);
+        termios_settings.c_iflag |= INPCK;
+    /* Only use ISTRIP when less than 8 bits as it strips the 8th bit */
+    if (parity != PARITY_NONE && databits != 8)
+        termios_settings.c_iflag |= ISTRIP;
     if (xonxoff)
         termios_settings.c_iflag |= (IXON | IXOFF);
 


### PR DESCRIPTION
When opening a serial port using serial_open_advanced which is
configured to be 8 data bits with a parity bit, the most significant
bit is strip from the data bits. This is caused by the ISTRIP flag
being set for the terminal attribute flags. Fix this by only setting
the ISTRIP flag when there are less than 8 data bits.

Details on ISTRIP flag:
https://www.gnu.org/software/libc/manual/html_node/Input-Modes.html

Signed-off-by: Ryan Barnett <ryan.barnett@rockwellcollins.com>