### PR TITLE
Add cmake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ obj/
 tests/*
 !tests/*.c
 !tests/*.h
+/*build/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,7 @@ compiler:
   - gcc
 
 script:
-    - make clean all tests
+    - mkdir build
+    - cd build
+    - cmake  ..
+    - make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,66 @@
+cmake_minimum_required(VERSION 2.6)
+project(c-periphery C)
+
+include(CheckIncludeFiles)
+
+CHECK_INCLUDE_FILES(linux/gpio.h HAVE_LINUX_HEADERS)
+if(NOT HAVE_LINUX_HEADERS)
+    message("c-periphery needs kernel headers")
+    return()
+endif()
+
+
+set(VERSION "2.1.0")
+set(SOVERSION ${VERSION})
+
+# Define COMMIT_ID
+execute_process(
+    COMMAND git describe --abbrev --always --tags --dirty
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    OUTPUT_VARIABLE COMMIT_ID
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+add_definitions(-DPERIPHERY_VERSION_COMMIT="${COMMIT_ID}")
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter -fPIC")
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+file(
+    GLOB_RECURSE
+    c_pheriphery_SOURCES
+    src/*.c
+)
+
+file(
+    GLOB_RECURSE
+    c_pheriphery_HEADERS
+    src/*.h
+)
+
+# Build shared library
+add_library(periphery ${c_pheriphery_SOURCES} ${c_pheriphery_HEADERS})
+set_target_properties(periphery PROPERTIES SOVERSION ${VERSION})
+
+# Install shared library and headers
+install(TARGETS periphery DESTINATION lib)
+install(FILES ${c_pheriphery_HEADERS} DESTINATION include/${PROJECT_NAME})
+
+# Build all tests contains in tests directory
+file(
+    GLOB_RECURSE
+    c_pheriphery_TESTS
+    tests/*.c
+)
+
+foreach(TEST_FILE ${c_pheriphery_TESTS})
+    get_filename_component(PROGRAM ${TEST_FILE} NAME_WE)
+    add_executable(${PROGRAM} ${TEST_FILE})
+    target_link_libraries(${PROGRAM} periphery pthread)
+    set(PROGRAMS ${PROGRAMS} ${PROGRAM})
+endforeach()
+
+add_custom_target(tests DEPENDS periphery ${PROGRAM_TESTS}
+COMMENT "Generating Test c-periphery API"
+VERBATIM)

--- a/README.md
+++ b/README.md
@@ -368,71 +368,64 @@ int main(void) {
 
 ## Building
 
-`make` will build c-periphery into a static library.
+Build c-periphery into a static library.
 
 ``` console
+$ mkdir build
+$ cd build
+$ cmake ..
 $ make
-mkdir obj
-cc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  -c src/gpio.c -o obj/gpio.o
-cc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  -c src/led.c -o obj/led.o
-cc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  -c src/pwm.c -o obj/pwm.o
-cc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  -c src/spi.c -o obj/spi.o
-cc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  -c src/i2c.c -o obj/i2c.o
-cc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  -c src/mmio.c -o obj/mmio.o
-cc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  -c src/serial.c -o obj/serial.o
-cc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  -c src/version.c -o obj/version.o
-ar rcs periphery.a obj/gpio.o obj/led.o obj/pwm.o obj/spi.o obj/i2c.o obj/mmio.o obj/serial.o obj/version.o
-$
+```
+
+Build c-periphery into a shared library.
+
+``` console
+$ mkdir build
+$ cd build
+$ cmake -DBUILD_SHARED_LIBS=ON ..
+$ make
 ```
 
 `make tests` will build the c-periphery tests.
 
 ``` console
 $ make tests
-cc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  tests/test_led.c periphery.a -o tests/test_led -lpthread
-cc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  tests/test_serial.c periphery.a -o tests/test_serial -lpthread
-cc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  tests/test_i2c.c periphery.a -o tests/test_i2c -lpthread
-cc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  tests/test_gpio_sysfs.c periphery.a -o tests/test_gpio_sysfs -lpthread
-cc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  tests/test_mmio.c periphery.a -o tests/test_mmio -lpthread
-cc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  tests/test_spi.c periphery.a -o tests/test_spi -lpthread
-cc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  tests/test_gpio.c periphery.a -o tests/test_gpio -lpthread
-cc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  tests/test_pwm.c periphery.a -o tests/test_pwm -lpthread
-$
 ```
 
 ### Cross-compilation
 
-Set the `CROSS_COMPILE` environment variable with the cross-compiler prefix when calling make:
+Set the `CC` environment variable with the cross-compiler :
 
 ``` console
-$ CROSS_COMPILE=arm-linux- make all tests
-mkdir obj
-arm-linux-gcc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  -c src/gpio.c -o obj/gpio.o
-arm-linux-gcc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  -c src/led.c -o obj/led.o
-arm-linux-gcc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  -c src/pwm.c -o obj/pwm.o
-arm-linux-gcc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  -c src/spi.c -o obj/spi.o
-arm-linux-gcc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  -c src/i2c.c -o obj/i2c.o
-arm-linux-gcc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  -c src/mmio.c -o obj/mmio.o
-arm-linux-gcc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  -c src/serial.c -o obj/serial.o
-arm-linux-gcc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  -c src/version.c -o obj/version.o
-arm-linux-ar rcs periphery.a obj/gpio.o obj/led.o obj/pwm.o obj/spi.o obj/i2c.o obj/mmio.o obj/serial.o obj/version.o
-arm-linux-gcc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  tests/test_led.c periphery.a -o tests/test_led -lpthread
-arm-linux-gcc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  tests/test_serial.c periphery.a -o tests/test_serial -lpthread
-arm-linux-gcc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  tests/test_i2c.c periphery.a -o tests/test_i2c -lpthread
-arm-linux-gcc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  tests/test_gpio_sysfs.c periphery.a -o tests/test_gpio_sysfs -lpthread
-arm-linux-gcc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  tests/test_mmio.c periphery.a -o tests/test_mmio -lpthread
-arm-linux-gcc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  tests/test_spi.c periphery.a -o tests/test_spi -lpthread
-arm-linux-gcc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  tests/test_gpio.c periphery.a -o tests/test_gpio -lpthread
-arm-linux-gcc -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter  -fPIC -DPERIPHERY_VERSION_COMMIT=\"v2.1.0\"  tests/test_pwm.c periphery.a -o tests/test_pwm -lpthread
-$
+$ export CC=arm-linux-gnueabihf-gcc
+$ mkdir build
+$ cd build
+$ cmake ..
+$ make
 ```
 
 ## Building c-periphery into another project
 
-Include the header files in `src/` (e.g. `gpio.h`, `led.h`, `pwm.h`, `spi.h`, `i2c.h`, `mmio.h`, `serial.h`) and link in the `periphery.a` static library.
+After build, install shared library and headers with :
+
+``` console
+$ sudo make install
+```
+
+## Building c-periphery into another project with static library
+
+Include the header files in `src/` (e.g. `gpio.h`, `led.h`, `pwm.h`, `spi.h`, `i2c.h`, `mmio.h`, `serial.h`) and link in the `periphery.a`.
 
 ``` console
 $ gcc -I/path/to/periphery/src myprog.c /path/to/periphery/periphery.a -o myprog
+```
+
+## Building c-periphery into another project with shared library
+
+Include the header files in `src/` (e.g. `c-periphery/gpio.h`, `c-periphery/led.h`, `c-periphery/pwm.h`, `c-periphery/spi.h`, `c-periphery/i2c.h`, `c-periphery/mmio.h`, `c-periphery/serial.h`) and link in the `-lperiphery`.
+
+``` console
+$ gcc myprog.c -lperiphery -o myprog
 ```
 
 ## Documentation


### PR DESCRIPTION
CMake is used to control the software compilation process
using simple platform and compiler independent configuration
files, and generate native makefiles and workspaces that
can be used in the compiler environment of your choice

see: https://cmake.org/

Also with cmake support build shared library to $libdir
and install headers files to $includir/c-periphery

Signed-off-by: Joris Offouga <offougajoris@gmail.com>