### PR TITLE
gpio.c: add _XOPEN_SOURCE define

### DIFF
--- a/src/gpio.c
+++ b/src/gpio.c
@@ -4,6 +4,8 @@
  * License: MIT
  */
 
+#define _XOPEN_SOURCE
+
 #include <stddef.h>
 #include <stdbool.h>
 #include <stdarg.h>


### PR DESCRIPTION
The code needs _XOPEN_SOURCE for some poll() flags.

Fix build with uclibc:
src/gpio.c: In function gpio_poll_multiple»:
src/gpio.c:242:61: error: «POLLRDNORM» undeclared (first use in this function)
(POLLPRI | POLLERR) : (POLLIN | POLLRDNORM);
                                ^

Signed-off-by: Joris Offouga <offougajoris@gmail.com>