### PR TITLE
CMakeLists.txt: add BUILD_TESTS option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.6)
 project(periphery C)
 
+option(BUILD_TESTS "Build tests" ON)
+
 # Check for Linux kernel headers
 include(CheckIncludeFiles)
 CHECK_INCLUDE_FILES(linux/gpio.h HAVE_LINUX_HEADERS)
@@ -44,11 +46,13 @@ install(TARGETS periphery DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(FILES ${periphery_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
 install(FILES ${CMAKE_BINARY_DIR}/libperiphery.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
-# Declare tests targets
-foreach(TEST_SOURCE ${periphery_TESTS})
-    get_filename_component(TEST_PROGRAM ${TEST_SOURCE} NAME_WE)
-    add_executable(${TEST_PROGRAM} ${TEST_SOURCE})
-    target_link_libraries(${TEST_PROGRAM} periphery pthread)
-    set(TEST_PROGRAMS ${TEST_PROGRAMS} ${TEST_PROGRAM})
-endforeach()
-add_custom_target(tests DEPENDS periphery ${TEST_PROGRAMS})
+if(BUILD_TESTS)
+    # Declare tests targets
+    foreach(TEST_SOURCE ${periphery_TESTS})
+        get_filename_component(TEST_PROGRAM ${TEST_SOURCE} NAME_WE)
+        add_executable(${TEST_PROGRAM} ${TEST_SOURCE})
+        target_link_libraries(${TEST_PROGRAM} periphery pthread)
+        set(TEST_PROGRAMS ${TEST_PROGRAMS} ${TEST_PROGRAM})
+    endforeach()
+    add_custom_target(tests DEPENDS periphery ${TEST_PROGRAMS})
+endif()


### PR DESCRIPTION
Add an option to enable or disable tests. This will allow the user to
build c-periphery without threads and will avoid the following build
failure:

```
[ 68%] Building C object CMakeFiles/test_serial.dir/tests/test_serial.c.o
/data/buildroot/buildroot-test/instance-0/output/build/c-periphery-2.2.1/tests/test_gpio_sysfs.c:13:10: fatal error: pthread.h: No such file or directory
 #include <pthread.h>
          ^~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/6bbc4de3f857dcb7ff5e6f9fa1441ba4e0af1338

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>