### PR TITLE
cmake: use relative source and binary directory paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,12 +37,12 @@ set_target_properties(periphery PROPERTIES SOVERSION ${VERSION})
 include(GNUInstallDirs)
 
 # Generate pkg-config pc file
-configure_file(${CMAKE_SOURCE_DIR}/src/libperiphery.pc.in ${CMAKE_BINARY_DIR}/libperiphery.pc @ONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/libperiphery.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libperiphery.pc @ONLY)
 
 # Declare install targets
 install(TARGETS periphery DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(FILES ${periphery_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
-install(FILES ${CMAKE_BINARY_DIR}/libperiphery.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libperiphery.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 # Declare tests targets
 foreach(TEST_SOURCE ${periphery_TESTS})


### PR DESCRIPTION
The config file is not always located in the top level directory of
source tree. So, CMAKE_CURRENT_BINARY_DIR and CMAKE_CURRENT_SOURCE_DIR
are a better alternative than CMAKE_SOURCE_DIR and CMAKE_BINARY_DIR