### PR TITLE
CMakeLists.txt: fix gpio detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@ project(periphery C)
 option(BUILD_TESTS "Build test programs" ON)
 
 # Check for Linux kernel header files for character device GPIO support
-include(CheckIncludeFiles)
-CHECK_INCLUDE_FILES(linux/gpio.h HAVE_CDEV_GPIO_HEADERS)
+include(CheckSymbolExists)
+CHECK_SYMBOL_EXISTS(GPIOEVENT_EVENT_RISING_EDGE linux/gpio.h HAVE_CDEV_GPIO_HEADERS)
 if(NOT HAVE_CDEV_GPIO_HEADERS)
 message(WARNING "Linux kernel header files not found for character device GPIO support. c-periphery will be built with legacy sysfs GPIO support only.")
 endif()


### PR DESCRIPTION
Commit 05262e6dc8424c21f0caf033b0473553825dac09 assumed that if linux/gpio.h is available then variables such as
GPIOEVENT_EVENT_RISING_EDGE are also available

This assumption is wrong, gpio.h is available since kernel 4.6 and
https://github.com/torvalds/linux/commit/3c702e9987e261042a07e43460a8148be254412e
but GPIOEVENT_REQUEST_RISING_EDGE is available only since kernel 4.8 and
https://github.com/torvalds/linux/commit/61f922db72216b00386581c851db9c9095961522

Fixes:
 - http://autobuild.buildroot.org/results/c3b868c12baac9438b792ada105c0b0de0106311

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>