### PR TITLE
Add GitHub actions for CMake and Buildroot

### DIFF
--- a/.github/workflows/buildroot.yml
+++ b/.github/workflows/buildroot.yml
@@ -1,0 +1,71 @@
+# Provide CI which utilize buildroot and the test-pkg utility to build c-periphery
+# against the following toolchains:
+#   - br-arm-full
+#       ARM toolchain with uClibc
+#   - br-arm-cortex-a9-glibc
+#       ARM toolchain with glibc and a very recent gcc version
+#   - br-arm-cortex-m4-full.
+#       ARM noMMU toolchain with no dynamic library support
+#   - br-x86-64-musl 
+#       x86-64 musl toolchain
+#   - br-arm-full-static
+#       ARM toolchain which is fully static (doesn't support dynamic libraries)
+#   - sourcery-arm 
+#       ARM toolchain with an old gcc version (gcc 4.8)
+#
+# Build logs are upload as part of the last step 
+
+name: Buildroot CI
+
+# Only run on MRs or push to non-master branches (for development)
+on: 
+  push:
+    branches-ignore: [master]
+  pull_request:
+    branches: [master]
+
+env:
+  # Version of buildroot to use to perform build tests
+  BR_VER: 2020.11.1
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      
+    # Need to perform clone/build tests outside of workspace
+    - name: Create Build Directory
+      shell: bash
+      run: mkdir -p ~/build
+    
+    # Clone Buildroot and create file(s) for building c-periphery with buildroot
+    # to utilize different toolchain types
+    - name: Check-out/Setup Buildroot
+      shell: bash
+      run: |
+        cd ~/build
+        git clone -b $BR_VER git://git.buildroot.net/buildroot
+        cd buildroot
+        echo "BR2_PACKAGE_C_PERIPHERY=y" > c-periphery.config
+        
+    # Run buildroot's test-pkg script to perform builds with different toolchains
+    - name: Buildroot 'test-pkg' Build
+      shell: bash
+      env:
+        # Utilize the current checkout of c-periphery with buildroot instead of released version
+        #   https://buildroot.org/downloads/manual/manual.html#_advanced_usage
+        C_PERIPHERY_OVERRIDE_SRCDIR: ${{github.workspace}}
+      run: |
+        cd ~/build/buildroot
+        # Runs builds against the 6 toolchains above and places artifacts in ~/build/br-test-pkg
+        ./utils/test-pkg -c c-periphery.config -p c-periphery -d "$(pwd)/../br-test-pkg"
+        
+    # Store build logs from test-pkg as artifacts
+    - name: Upload Buildroot Logfiles
+      uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: logfiles
+        path:  ~/build/br-test-pkg/**/logfile

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,39 @@
+name: CMake
+
+on:
+  push:
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    # Perform build with GCC and Clang for C compiler
+    #   https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    strategy: 
+      matrix:
+        cc: [/usr/bin/gcc, /usr/bin/clang]
+  
+    env:
+      CC: ${{ matrix.cc }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Create Build Environment
+      # We'll use this as our working directory for all subsequent commands
+      run: cmake -E make_directory ${{github.workspace}}/build
+
+    - name: Configure CMake
+      # Use a bash shell so we can use the same syntax for environment variable
+      # access regardless of the host operating system
+      shell: bash
+      working-directory: ${{github.workspace}}/build
+      run: cmake $GITHUB_WORKSPACE
+
+    - name: Build
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      # Execute the build
+      run: make


### PR DESCRIPTION
In order to better improve CI testing of the c-periphery and allow CI to be run by forked repositories, add support for GitHub actions. The two main actions added are:

* cmake
  * Run builds on ubuntu-latest using CMake with GCC and Clang in a build matrix. This is a direct port of the functionality of the .travis.yml file
* buildroot
  *  Utilize buildroot's test-pkg and the ability to use local source code to perform a build for a package to perform builds using 6 toolchains: br-arm-full, br-arm-cortex-a9-glibc, br-arm-cortex-m4-full, br-x86-64-musl, br-arm-full-static, sourcery-arm 

The benefits allow better testing of corner cases and common issues that get fix when new releases are integrated into buildroot (which is how the issue with the 32-bit SPI extra_flags was found). 

See commit log messages for further details, especially for the buildroot action.

For example of checks - see this example MR I created on my forked repo:

https://github.com/rjbarnet/c-periphery/pull/3
