### PR TITLE
Add cmake-config support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,11 +44,14 @@ add_definitions(-DPERIPHERY_VERSION_COMMIT="${COMMIT_ID}")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -pedantic -Wall -Wextra -Wno-stringop-truncation -fPIC")
 set(CMAKE_C_FLAGS_DEBUG "-g")
 set(CMAKE_C_FLAGS_RELEASE "-O3")
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 # Declare library target
 add_library(periphery ${periphery_SOURCES} ${periphery_HEADERS})
 set_target_properties(periphery PROPERTIES SOVERSION ${VERSION})
+target_include_directories(periphery PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+)
 
 include(GNUInstallDirs)
 
@@ -59,6 +62,20 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/libperiphery.pc.in ${CMAKE_CURREN
 install(TARGETS periphery DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(FILES ${periphery_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libperiphery.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}-config
+  RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(
+  EXPORT ${PROJECT_NAME}-config
+  NAMESPACE ${PROJECT_NAME}::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)
 
 # Declare test targets if enabled
 if(BUILD_TESTS)

--- a/README.md
+++ b/README.md
@@ -474,8 +474,15 @@ Otherwise, additional include (`-I`) and library (`-L`) paths may be required.
 ### Use CMake
 
 ```cmake
+# use this line by default
 find_package(periphery REQUIRED)
-target_link_libraries(YOUR_TARGET periphery::periphery)
+# if not find use this one
+# find_package(periphery REQUIRED PATHS <path to install/dir/lib/cmake>)
+
+...
+
+add_executable(YOUR_TARGET src/main.cc)
+target_link_libraries(YOUR_TARGET PRIVATE periphery::periphery)
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -471,6 +471,13 @@ $ gcc myprog.c -lperiphery -o myprog
 
 Otherwise, additional include (`-I`) and library (`-L`) paths may be required.
 
+### Use CMake
+
+```cmake
+find_package(periphery REQUIRED)
+target_link_libraries(YOUR_TARGET periphery::periphery)
+```
+
 ## Documentation
 
 `man` page style documentation for each interface wrapper is available in [docs](docs/) folder.


### PR DESCRIPTION
cmake-config is used with `find_package`, its the commonly used basic instruction of CMake

compared to others, the use of pkg-config is more inconvenient