### PR TITLE
Enhance makefile portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,17 @@ TEST_PROGRAMS = $(basename $(wildcard tests/*.c))
 
 OBJECTS = $(patsubst $(SRCDIR)/%.c,$(OBJDIR)/%.o,$(SRCS))
 
-GPIO_CDEV_V1_SUPPORT := $(shell ! echo -e "#include <linux/gpio.h>\n#ifndef GPIO_GET_LINEEVENT_IOCTL\n#error\n#endif" | $(CC) -E - >/dev/null 2>&1; echo $$?)
-GPIO_CDEV_V2_SUPPORT := $(shell ! echo -e "#include <linux/gpio.h>\nint main(void) { GPIO_V2_LINE_FLAG_EVENT_CLOCK_REALTIME; return 0; }" | $(CC) -x c - >/dev/null 2>&1; echo $$?)
+ifeq ($(OS),Windows_NT)
+	NULL := NUL
+else
+	NULL := /dev/null
+endif
+
+GPIO_CDEV_V1_SUPPORT := $(shell ! echo -e "\x23include <linux/gpio.h>\n\x23ifndef GPIO_GET_LINEEVENT_IOCTL\n\x23error\n\x23endif" | $(CC) -E - >$(NULL) 2>&1; echo $$?)
+GPIO_CDEV_V2_SUPPORT := $(shell ! echo -e "\x23include <linux/gpio.h>\nint main(void) { GPIO_V2_LINE_FLAG_EVENT_CLOCK_REALTIME; return 0; }" | $(CC) -x c - >$(NULL) 2>&1; echo $$?)
 GPIO_CDEV_SUPPORT = $(if $(filter 1,$(GPIO_CDEV_V2_SUPPORT)),2,$(if $(filter 1,$(GPIO_CDEV_V1_SUPPORT)),1,0))
 
-COMMIT_ID := $(shell git describe --abbrev --always --tags --dirty 2>/dev/null || echo "")
+COMMIT_ID := $(shell git describe --abbrev --always --tags --dirty 2>$(NULL) || echo "")
 
 OPT ?= -O3
 CFLAGS += -std=gnu99 -pedantic


### PR DESCRIPTION
Hello,

This pull request is an attempt to enhance the portability of the makefile.

There are 2 enhancements:
1. The usage of the number signs '`#`' appearing inside a function is treated as a comment in make version prior 4.3
2. The null device is `NUL` on Windows OS which forbids cross compilation

Thank you for your work and have a good day,
Samuel